### PR TITLE
Add udev rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ A ROS Package for Respeaker Mic Array
     source ~/catkin_ws/devel/setup.bash
     ```
 
+1. Register respeaker udev rules
+
+    Normally, we cannot access USB device without permission from user space.
+    Using `udev`, we can give the right permission on only respeaker device automatically.
+
+    Please run the command as followings to install setting file:
+
+    ```bash
+    roscd respeaker_ros
+    sudo cp -f $(rospack find respeaker_ros)/config/60-respeaker.rules /etc/udev/rules.d/60-respeaker.rules
+    sudo systemctl restart udev
+    ```
+
+    And then re-connect the device.
+
 1. Install python requirements
 
     ```bash

--- a/config/60-respeaker.rules
+++ b/config/60-respeaker.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idProduct}=="0018", ATTR{idVendor}=="2886", MODE:="0666"

--- a/launch/respeaker.launch
+++ b/launch/respeaker.launch
@@ -2,5 +2,5 @@
   <node name="respeaker_node" pkg="respeaker_ros" type="respeaker_node.py"/>
 
   <node name="static_transformer" pkg="tf" type="static_transform_publisher"
-        args="0 0 0 0 0 map respeaker_base 100"/>
+        args="0 0 0 0 0 0 map respeaker_base 100"/>
 </launch>


### PR DESCRIPTION
Closes #4 

In this PR, a rule file for `udev` is added to give proper permission to respeaker device automatically.