### PR TITLE
Depend on portaudio19-dev to install pyaudio

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>catkin_virtualenv</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>portaudio19-dev</build_depend>
   <run_depend>angles</run_depend>
   <run_depend>audio_common_msgs</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>


### PR DESCRIPTION
https://stackoverflow.com/questions/42038991/error-while-upgrading-pyaudio-to-latest-version