### PR TITLE
Publish all channels

### DIFF
--- a/scripts/respeaker_node.py
+++ b/scripts/respeaker_node.py
@@ -288,7 +288,7 @@ class RespeakerAudio(object):
             chan_data = data[:, chan]
             # invoke callback
             self.on_audio(chan_data.tostring(), chan)
-            return None, pyaudio.paContinue
+        return None, pyaudio.paContinue
 
     def start(self):
         if self.stream.is_stopped():
@@ -326,7 +326,7 @@ class RespeakerNode(object):
         self.pub_doa = rospy.Publisher("sound_localization", PoseStamped, queue_size=1, latch=True)
         self.pub_audio = rospy.Publisher("audio", AudioData, queue_size=10)
         self.pub_speech_audio = rospy.Publisher("speech_audio", AudioData, queue_size=10)
-        self.pub_audios = {c:rospy.Publisher('audio/channel%d' % c) for c in self.respeaker_audio.channels}
+        self.pub_audios = {c:rospy.Publisher('audio/channel%d' % c, AudioData, queue_size=10) for c in self.respeaker_audio.channels}
         # init config
         self.config = None
         self.dyn_srv = Server(RespeakerConfig, self.on_config)

--- a/scripts/respeaker_node.py
+++ b/scripts/respeaker_node.py
@@ -118,7 +118,7 @@ class RespeakerInterface(object):
         self.dev.reset()
         self.pixel_ring = usb_pixel_ring_v2.PixelRing(self.dev)
         self.set_led_think()
-        time.sleep(5)  # it will take 5 seconds to re-recognize as audio device
+        time.sleep(10)  # it will take 10 seconds to re-recognize as audio device
         self.set_led_trace()
         rospy.loginfo("Respeaker device initialized (Version: %s)" % self.version)
 


### PR DESCRIPTION
- Increase waiting time on USB reset for environments where many usb devices are connected. (it takes longer time)
- Added an option `~main_channel` for selecting channel to be used for speech recognition and VAD.
- Added publishers for all 6 channels of respeaker microphone.

Topics are listed as below:

```
$ rostopic list | grep audio
/audio
/audio/channel0
/audio/channel1
/audio/channel2
/audio/channel3
/audio/channel4
/audio/channel5
```

If `~main_channel` is `0`, data published as `/audio` and `/audio/channel0` is the same.